### PR TITLE
feat: Add GraphQL support

### DIFF
--- a/__tests__/graphql/queries/index.ts
+++ b/__tests__/graphql/queries/index.ts
@@ -1,0 +1,84 @@
+export const transactionsQuery = `query($count: Int){
+    transactions(
+      first: $count
+    ) {
+      edges{
+        cursor
+        node {
+          id
+          owner {
+            address
+          }
+          data {
+            size
+          }
+          block {
+            height
+            timestamp
+          }
+          tags {
+            name,
+            value
+          }
+        }
+      }
+    }
+  }`;
+
+export const transactionsWithTagFilterQuery = `query($count: Int $tags: [TagFilter!]){
+    transactions(
+      first: $count
+      tags: $tags
+    ) {
+      edges{
+        node {
+          id
+          owner {
+            address
+          }
+          data {
+            size
+          }
+          block {
+            height
+            timestamp
+          }
+          tags {
+            name,
+            value
+          }
+        }
+      }
+    }
+  }`;
+
+export const transactionsWithPageInfo = `query($count: Int $cursor: String){
+    transactions(
+      after: $cursor
+      first: $count
+    ) {
+      pageInfo {
+        hasNextPage
+      }
+      edges{
+        cursor
+        node {
+          id
+          owner {
+            address
+          }
+          data {
+            size
+          }
+          block {
+            height
+            timestamp
+          }
+          tags {
+            name,
+            value
+          }
+        }
+      }
+    }
+  }`;

--- a/__tests__/graphql/queries/test.json
+++ b/__tests__/graphql/queries/test.json
@@ -1,0 +1,219 @@
+{
+  "responses": {
+    "transactionsFilteredByTagsQuery": {
+      "transactions": {
+        "edges": [
+          {
+            "node": {
+              "id": "O38h92MH4LL8NNL23SYQ5NU6enxsDqgWrMxVlq1ot4Y",
+              "owner": {
+                "address": "hctnleYoGzMf55h3C4pnG3luEUElXkvJj7XWSv7NpUM"
+              },
+              "data": {
+                "size": "4"
+              },
+              "block": {
+                "height": 1213000,
+                "timestamp": 1688459468
+              },
+              "tags": [
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain"
+                },
+                {
+                  "name": "App-Name",
+                  "value": "PublicSquare"
+                },
+                {
+                  "name": "Version",
+                  "value": "2"
+                },
+                {
+                  "name": "Type",
+                  "value": "like"
+                },
+                {
+                  "name": "Like-Target",
+                  "value": "AsoWwoBEmV-kODw8kj1oqI7nSSbGiWQx1Mr5wF3nvoo"
+                },
+                {
+                  "name": "Signing-Client",
+                  "value": "ArConnect"
+                },
+                {
+                  "name": "Signing-Client-Version",
+                  "value": "0.5.5"
+                }
+              ]
+            }
+          },
+          {
+            "node": {
+              "id": "TwPmuXXONFUW0HMWa5PDHJ6zPTtKpIyRWfbxjqa7lwg",
+              "owner": {
+                "address": "gXHKPxr7R8ItdidbzzWZLo_ww5JVVFi-fOUxcL6Fnfg"
+              },
+              "data": {
+                "size": "4"
+              },
+              "block": {
+                "height": 1166900,
+                "timestamp": 1682557862
+              },
+              "tags": [
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain"
+                },
+                {
+                  "name": "App-Name",
+                  "value": "PublicSquare"
+                },
+                {
+                  "name": "Version",
+                  "value": "2"
+                },
+                {
+                  "name": "Type",
+                  "value": "like"
+                },
+                {
+                  "name": "Like-Target",
+                  "value": "tGSYG9bprxPaVX3lsOoh7Q1rT1lr3H6NYFaTETvpj8w"
+                }
+              ]
+            }
+          },
+          {
+            "node": {
+              "id": "o5zisaTvcBDmNW_W-ZdQp99Fu4cqHH3BebxR1xDZqaA",
+              "owner": {
+                "address": "vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI"
+              },
+              "data": {
+                "size": "18"
+              },
+              "block": {
+                "height": 1154051,
+                "timestamp": 1680900212
+              },
+              "tags": [
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain"
+                },
+                {
+                  "name": "App-Name",
+                  "value": "PublicSquare"
+                },
+                {
+                  "name": "Version",
+                  "value": "2"
+                },
+                {
+                  "name": "Type",
+                  "value": "ProfileBannerImage"
+                },
+                {
+                  "name": "Img-Src-Id",
+                  "value": "_kJfWVKq-gYNv9QKEotoK8xwmjOD4Q4hbuf5vfgXfHQ"
+                }
+              ]
+            }
+          },
+          {
+            "node": {
+              "id": "CoHPc7xQFqZjK8Ycr3rqbnjLhtyrkrWj_ConTuPInfo",
+              "owner": {
+                "address": "vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI"
+              },
+              "data": {
+                "size": "66"
+              },
+              "block": {
+                "height": 1142726,
+                "timestamp": 1679445720
+              },
+              "tags": [
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain"
+                },
+                {
+                  "name": "App-Name",
+                  "value": "PublicSquare"
+                },
+                {
+                  "name": "Version",
+                  "value": "1"
+                },
+                {
+                  "name": "Type",
+                  "value": "post"
+                },
+                {
+                  "name": "App-Name",
+                  "value": "SmartWeaveContract"
+                },
+                {
+                  "name": "App-Version",
+                  "value": "0.3.0"
+                },
+                {
+                  "name": "Contract-Src",
+                  "value": "x0ojRwrcHBmZP20Y4SY0mgusMRx-IYTjg5W8c3UFoNs"
+                },
+                {
+                  "name": "Init-State",
+                  "value": "{\"pairs\":[],\"balances\":{\"vh-NTHVvlKZqRxc8LyyTNok65yQ55a_PJ1zWLb9G2JI\":1000000000000},\"name\":\"Atomic Token\",\"ticker\":\"ATOMIC\",\"settings\":[[\"isTradeable\",true]]}"
+                },
+                {
+                  "name": "Signing-Client",
+                  "value": "ArConnect"
+                },
+                {
+                  "name": "Signing-Client-Version",
+                  "value": "0.5.2"
+                }
+              ]
+            }
+          },
+          {
+            "node": {
+              "id": "EcUUPmdFPymXmzWvxs7Vwk_A2Fd5Hr1sahaOakeUP0Q",
+              "owner": {
+                "address": "DHbVxvDU6vu87xeefDPzWVghaZTTa81KLC67SspRUik"
+              },
+              "data": {
+                "size": "912"
+              },
+              "block": {
+                "height": 1137868,
+                "timestamp": 1678816928
+              },
+              "tags": [
+                {
+                  "name": "App-Name",
+                  "value": "PublicSquare"
+                },
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain"
+                },
+                {
+                  "name": "Version",
+                  "value": "1.0.1"
+                },
+                {
+                  "name": "Type",
+                  "value": "post"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/__tests__/graphql/query.spec.ts
+++ b/__tests__/graphql/query.spec.ts
@@ -1,0 +1,145 @@
+import { queryGQL, queryTransactionsGQL } from '../../src';
+import * as Types from '../../src/types/graphql';
+import {
+  transactionsQuery,
+  transactionsWithTagFilterQuery,
+  transactionsWithPageInfo,
+} from './queries';
+import mockedResponses from './queries/test.json';
+
+describe('Query GraphQL endpoint with `queryGQL`', () => {
+  it('should run and return first 10 transactions', async () => {
+    const { data, errors, status } = await queryGQL(transactionsQuery, {
+      gateway: 'arweave.dev',
+      filters: {
+        count: 10,
+      },
+    });
+
+    expect(status).toBe(200);
+    expect(data).not.toBeNull();
+    expect(errors).toBeNull();
+    expect(data?.transactions.edges.length).toBe(10);
+  });
+
+  it('should get 5 transactions filtered by tags', async () => {
+    const { data, errors, status } = await queryGQL(
+      transactionsWithTagFilterQuery,
+      {
+        gateway: 'arweave.dev',
+        filters: {
+          count: 5,
+          tags: [
+            {
+              name: 'App-Name',
+              values: ['PublicSquare'],
+            },
+            {
+              name: 'Content-Type',
+              values: ['text/plain'],
+            },
+          ],
+        },
+      }
+    );
+
+    expect(status).toBe(200);
+    expect(data).not.toBeNull();
+    expect(errors).toBeNull();
+
+    expect(data).toEqual(
+      mockedResponses.responses.transactionsFilteredByTagsQuery
+    );
+  });
+
+  it('should produce errors when invalid query is passed', async () => {
+    const { data, errors, status } = await queryGQL(`invalid`, {
+      gateway: 'arweave.dev',
+      filters: {
+        count: 5,
+      },
+    });
+
+    expect(status).toBe(400);
+    expect(data).toBeNull();
+    expect(errors).not.toBeNull();
+  });
+});
+
+describe('Query GraphQL endpoint with `queryTransactionsGQL`', () => {
+  it('should get 5 transactions with cursor for pagniation', async () => {
+    const { data, errors, status, cursor, hasNextPage } =
+      await queryTransactionsGQL(transactionsWithPageInfo, {
+        gateway: 'arweave.dev',
+        filters: {
+          count: 5,
+          cursor: '',
+        },
+      });
+
+    expect(status).toBe(200);
+    expect(cursor).not.toBeNull();
+    expect(data).not.toBeNull();
+    expect(errors).toBeNull();
+
+    expect(data.length).toBe(5);
+    expect(hasNextPage).toBeTruthy();
+  });
+
+  it('should get 3 pages of transactions with 5 items per page', async () => {
+    let LIMIT_PER_PAGE = 5;
+    let page = 1;
+    let numberOfPagesToGet = 3;
+
+    const dataSets: Types.GQLEdge[][] = [];
+    let cursor = '';
+    let hasNextPage = true;
+
+    while (page <= numberOfPagesToGet) {
+      if (!hasNextPage) break;
+
+      const {
+        data,
+        errors,
+        cursor: currentCursor,
+        hasNextPage: _hasNextPage,
+      } = await queryTransactionsGQL(transactionsWithPageInfo, {
+        gateway: 'arweave.dev',
+        filters: {
+          count: LIMIT_PER_PAGE,
+          cursor,
+        },
+      });
+
+      if (!errors) {
+        dataSets.push(data);
+        cursor = currentCursor;
+        hasNextPage = _hasNextPage;
+      }
+
+      page++;
+    }
+
+    expect(dataSets.length).toBe(numberOfPagesToGet);
+    expect(cursor).not.toBe('');
+
+    const [firstPage, secondPage, thirdPage] = dataSets;
+
+    expect(firstPage.length).toBe(5);
+    expect(secondPage.length).toBe(5);
+    expect(thirdPage.length).toBe(5);
+  });
+
+  it('should produce errors when invalid query is passed', async () => {
+    const { data, errors, status } = await queryTransactionsGQL(`invalid`, {
+      gateway: 'arweave.dev',
+      filters: {
+        count: 5,
+      },
+    });
+
+    expect(status).toBe(400);
+    expect(data).toEqual([]);
+    expect(errors).not.toBeNull();
+  });
+});

--- a/__tests__/graphql/query.spec.ts
+++ b/__tests__/graphql/query.spec.ts
@@ -1,4 +1,4 @@
-import { queryGQL, queryTransactionsGQL } from '../../src';
+import { queryGQL, queryTransactionsGQL } from '../../src/lib/graphql';
 import * as Types from '../../src/types/graphql';
 import {
   transactionsQuery,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@three-em/node": "^0.3.22",
     "arweave": "^1.13.5",
     "arweave-mnemonic-keys": "^0.0.9",
+    "graphql": "^16.7.1",
     "othent": "^1.0.634",
     "warp-contracts": "^1.4.1",
     "warp-contracts-plugin-deploy": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arweavekit",
-  "version": "1.2.14",
+  "version": "1.3.0",
   "description": "Utility library to build full stack permaweb applications",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
   postTransaction,
   getTransaction,
   getTransactionStatus,
-  createAndPostTransactionWOthent
+  createAndPostTransactionWOthent,
 } from './lib/transaction';
 export {
   createContract,
@@ -22,3 +22,4 @@ export {
   readServerlessFunction,
   testServerlessFunction,
 } from './lib/serverless';
+export { queryGQL, queryTransactionsGQL } from './lib/graphql';

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,4 +22,8 @@ export {
   readServerlessFunction,
   testServerlessFunction,
 } from './lib/serverless';
-export { queryGQL, queryTransactionsGQL } from './lib/graphql';
+export {
+  queryGQL,
+  queryTransactionsGQL,
+  queryAllTransactionsGQL,
+} from './lib/graphql';

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -20,6 +20,7 @@ export async function queryGQL(
     const queryAST = parse(query);
     const schema = buildSchema(graphQlSchemaString);
     const result = validate(schema, queryAST);
+
     validationResult = [...result];
   } catch (error: any) {
     validationResult.push(new GraphQLError(error.message));
@@ -81,6 +82,33 @@ export async function queryTransactionsGQL(
     cursor,
     hasNextPage,
   };
+}
+
+export async function queryAllTransactionsGQL(
+  query: string,
+  options: Types.QueryGQLOptions
+) {
+  const dataSet: Types.GQLEdge[] = [];
+
+  let cursor = '';
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const {
+      data,
+      errors,
+      cursor: currentCursor,
+      hasNextPage: _hasNextPage,
+    } = await queryTransactionsGQL(query, { ...options, cursor });
+
+    if (!errors) {
+      dataSet.push(...data);
+      cursor = currentCursor;
+      hasNextPage = _hasNextPage;
+    }
+  }
+
+  return dataSet;
 }
 
 function initArweave(gateway: string) {

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -1,0 +1,50 @@
+import Arweave from 'arweave';
+
+import * as Types from '../types/graphql';
+import { ARWEAVE_GATEWAYS } from '../utils';
+
+/**
+ * Query data with GraphQL endpoint
+ * @params QueryGQLOptions
+ * @returns QueryGQLResult
+ */
+
+export async function queryGQL(
+  query: string,
+  options: Types.QueryGQLOptions
+): Promise<Types.QueryGQLResult> {
+  const arweave = initArweave(options.gateway);
+
+  const payload = {
+    query,
+    variables: options.filters,
+  };
+  const results = await arweave.api.post<Types.GQLResult>('/graphql', payload);
+
+  return {
+    status: results.status,
+    data: results.data.data ?? null,
+    errors: results.data.errors ?? null,
+  };
+}
+
+function initArweave(gateway: string) {
+  const LOCAL_GATEWAY_CONFIG = {
+    host: 'localhost',
+    port: 1984,
+    protocol: 'http',
+  };
+  const MAINNET_GATEWAY_CONFIG = {
+    host: gateway || ARWEAVE_GATEWAYS[0],
+    port: 443,
+    protocol: 'https',
+  };
+
+  let config = MAINNET_GATEWAY_CONFIG;
+
+  if (gateway.indexOf('localhost') > -1) {
+    config = LOCAL_GATEWAY_CONFIG;
+  }
+
+  return Arweave.init(config);
+}

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -101,11 +101,13 @@ export async function queryAllTransactionsGQL(
       hasNextPage: _hasNextPage,
     } = await queryTransactionsGQL(query, { ...options, cursor });
 
-    if (!errors) {
-      dataSet.push(...data);
-      cursor = currentCursor;
-      hasNextPage = _hasNextPage;
+    if (errors && !data.length) {
+      break;
     }
+
+    dataSet.push(...data);
+    cursor = currentCursor;
+    hasNextPage = _hasNextPage;
   }
 
   return dataSet;

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -28,6 +28,41 @@ export async function queryGQL(
   };
 }
 
+/**
+ * Query transactions with pagination on GraphQL endpoint
+ * @params QueryTransactionsGQLOptions
+ * @returns QueryTransactionsGQLResult
+ */
+
+export async function queryTransactionsGQL(
+  query: string,
+  options: Types.QueryTransactionsGQLOptions
+): Promise<Types.QueryTransactionsGQLResult> {
+  let cursor = options.cursor || '';
+  let hasNextPage = false;
+  const filters = options.filters || {};
+
+  const { data, errors, status } = await queryGQL(query, {
+    ...options,
+    filters: { ...filters, cursor },
+  });
+
+  const edges = data?.transactions?.edges || [];
+
+  if (edges.length) {
+    cursor = edges[edges.length - 1].cursor;
+    hasNextPage = data?.transactions?.pageInfo?.hasNextPage || false;
+  }
+
+  return {
+    status,
+    data: edges,
+    errors,
+    cursor,
+    hasNextPage,
+  };
+}
+
 function initArweave(gateway: string) {
   const LOCAL_GATEWAY_CONFIG = {
     host: 'localhost',

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1,4 +1,5 @@
 import { ARWEAVE_GATEWAYS } from '../utils';
+import { GraphQLError as ActualGraphQLError } from 'graphql';
 
 export type QueryGQLOptions = {
   gateway: string;
@@ -10,13 +11,13 @@ export type QueryTransactionsGQLOptions = QueryGQLOptions & { cursor?: string };
 export type QueryGQLResult = {
   status: number;
   data: GraphQLData | null;
-  errors: GraphQLError[] | null;
+  errors: GraphQLError[] | readonly ActualGraphQLError[] | null;
 };
 
 export type QueryTransactionsGQLResult = {
   status: number;
   data: GQLEdge[];
-  errors: GraphQLError[] | null;
+  errors: GraphQLError[] | readonly ActualGraphQLError[] | null;
   cursor: string;
   hasNextPage: boolean;
 };

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -5,10 +5,20 @@ export type QueryGQLOptions = {
   filters: Record<string, unknown>;
 };
 
+export type QueryTransactionsGQLOptions = QueryGQLOptions & { cursor?: string };
+
 export type QueryGQLResult = {
   status: number;
   data: GraphQLData | null;
   errors: GraphQLError[] | null;
+};
+
+export type QueryTransactionsGQLResult = {
+  status: number;
+  data: GQLEdge[];
+  errors: GraphQLError[] | null;
+  cursor: string;
+  hasNextPage: boolean;
 };
 
 export interface GQLNode {
@@ -76,4 +86,4 @@ export type GraphQLError = {
   };
 };
 
-export type Gateway = typeof ARWEAVE_GATEWAYS[number];
+export type Gateway = (typeof ARWEAVE_GATEWAYS)[number];

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1,0 +1,79 @@
+import { ARWEAVE_GATEWAYS } from '../utils';
+
+export type QueryGQLOptions = {
+  gateway: string;
+  filters: Record<string, unknown>;
+};
+
+export type QueryGQLResult = {
+  status: number;
+  data: GraphQLData | null;
+  errors: GraphQLError[] | null;
+};
+
+export interface GQLNode {
+  id: string;
+  anchor: string;
+  signature: string;
+  recipient: string;
+  owner: {
+    address: string;
+    key: string;
+  };
+  fee: {
+    winston: string;
+    ar: string;
+  };
+  quantity: {
+    winston: string;
+    ar: string;
+  };
+  data: {
+    size: number;
+    type: string;
+  };
+  tags: Array<{
+    name: string;
+    value: string;
+  }>;
+  block: {
+    id: string;
+    timestamp: number;
+    height: number;
+    previous: string;
+  };
+  parent: {
+    id: string;
+  };
+}
+
+export interface GQLEdge {
+  cursor: string;
+  node: GQLNode;
+}
+
+export interface GQLTransactionsResult {
+  pageInfo: {
+    hasNextPage: boolean;
+  };
+  edges: GQLEdge[];
+}
+
+export interface GQLResult {
+  data: GraphQLData;
+  errors?: Array<GraphQLError>;
+}
+
+export type GraphQLData = {
+  transaction: GQLNode;
+  transactions: GQLTransactionsResult;
+};
+
+export type GraphQLError = {
+  message: string;
+  extensions: {
+    code: string;
+  };
+};
+
+export type Gateway = typeof ARWEAVE_GATEWAYS[number];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,3 +45,153 @@ export const ARWEAVE_GATEWAYS = [
   'g8way.io',
   'arweave-search.goldsky.com',
 ] as const;
+
+export const graphQlSchemaString = `
+type Query {
+  transaction(id: ID!): Transaction
+
+  transactions(
+    ids: [ID!]
+
+    owners: [String!]
+
+    recipients: [String!]
+
+    tags: [TagFilter!]
+
+    bundledIn: [ID!]
+
+    block: BlockFilter
+
+    first: Int = 10
+
+    after: String
+
+    sort: SortOrder = HEIGHT_DESC
+  ): TransactionConnection!
+  block(id: String): Block
+  blocks(
+    ids: [ID!]
+
+    height: BlockFilter
+
+    first: Int = 10
+
+    after: String
+
+    sort: SortOrder = HEIGHT_DESC
+  ): BlockConnection!
+}
+type Owner {
+  address: String!
+  key: String!
+}
+
+type Amount {
+  winston: String!
+  ar: String!
+}
+
+type MetaData {
+  size: String!
+  type: String
+}
+
+type Tag {
+  name: String!
+  value: String!
+}
+
+# Block Schema
+type Block {
+  id: ID!
+  timestamp: Int!
+  height: Int!
+  previous: ID!
+}
+
+type Parent {
+  id: ID!
+}
+
+type Bundle {
+  # ID of the containing data bundle.
+  id: ID!
+}
+
+type Transaction {
+  id: ID!
+  anchor: String!
+  signature: String!
+  recipient: String!
+  owner: Owner!
+  fee: Amount!
+  quantity: Amount!
+  data: MetaData!
+  tags: [Tag!]!
+
+  block: Block
+
+  parent: Parent @deprecated(reason: "Use 'bundledIn'")
+  bundledIn: Bundle
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+}
+
+type TransactionEdge {
+  cursor: String!
+  node: Transaction!
+}
+
+type TransactionConnection {
+  pageInfo: PageInfo!
+  edges: [TransactionEdge!]!
+}
+
+type BlockEdge {
+  cursor: String!
+  node: Block!
+}
+
+type BlockConnection {
+  pageInfo: PageInfo!
+  edges: [BlockEdge!]!
+}
+
+input TagFilter {
+  name: String
+
+  values: [String!]
+
+  op: TagOperator = EQ
+
+  match: TagMatch = EXACT
+}
+
+enum TagOperator {
+  EQ
+
+  NEQ
+}
+
+# The method used to determine if tags match.
+enum TagMatch {
+  EXACT
+  WILDCARD
+  FUZZY_AND
+  FUZZY_OR
+}
+
+input BlockFilter {
+  min: Int
+
+  max: Int
+}
+
+enum SortOrder {
+  HEIGHT_ASC
+  HEIGHT_DESC
+}
+`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,10 @@ export async function fileToBuffer(file: File): Promise<ArrayBuffer> {
     reader.readAsArrayBuffer(file);
   });
 }
+
+export const ARWEAVE_GATEWAYS = [
+  'arweave.net',
+  'arweave.dev',
+  'g8way.io',
+  'arweave-search.goldsky.com',
+] as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "sourceMap": true,
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4607,6 +4607,11 @@ graphql@^16.2.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
+graphql@^16.7.1:
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.7.1.tgz#11475b74a7bff2aefd4691df52a0eca0abd9b642"
+  integrity sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"


### PR DESCRIPTION
## Summary 
This PR adds support to query GraphQL endpoint of selected gateway and query Transactions data via GraphQL endpoint with the help of newly introduced methods `queryGQL`, `queryTransactionsGQL`, `queryAllTransactionsGQL`.

- `queryGQL` will take in a valid Arweave GraphQL query with supported filters and return a raw GQL response.
- `queryTransactionsGQL` will take in a valid Arweave GraphQL query in a suggested format so that consumer can utilize cursor based pagination support provided by this method.
- `queryAllTransactionsGQL` will take in a valid Areave GraphQL query in a suggested format and iteratively fetches all transactions then return it to the consumer.

These methods pre-validates user's supplied query by parsing it into AST and further using `validate` method from `graphql` package. With this validation, we can make sure to catch silly mistakes or invalid query that is not as per schema.

## Tests
Added unit tests for both of the methods covering common scenarios

## Further notes
- None
