### PR TITLE
Fix/browser issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@bundlr-network/client": "0.11.9",
+    "@bundlr-network/client": "^0.11.12",
     "@metamask/providers": "^11.1.0",
     "arweave": "^1.13.5",
     "arweave-mnemonic-keys": "^0.0.9",

--- a/src/lib/graphql.ts
+++ b/src/lib/graphql.ts
@@ -113,7 +113,7 @@ export async function queryAllTransactionsGQL(
   return dataSet;
 }
 
-function initArweave(gateway: string) {
+function initArweave(gateway: string): Arweave {
   const LOCAL_GATEWAY_CONFIG = {
     host: 'localhost',
     port: 1984,
@@ -131,7 +131,7 @@ function initArweave(gateway: string) {
     config = LOCAL_GATEWAY_CONFIG;
   }
 
-  return Arweave.init(config);
+  return ((Arweave as any)?.default ?? Arweave).init(config);
 }
 
 export const ARWEAVE_GATEWAYS = [

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -6,15 +6,16 @@ import { Othent as othent } from 'othent';
 import { ethers } from 'ethers';
 
 async function initArweave(params: Types.InitArweaveProps) {
-  let arweave;
+  let arweave: Arweave;
+  const ArweaveClass = (Arweave as any)?.default ?? Arweave;
   if (params.environment === 'local') {
-    arweave = Arweave.init({
+    arweave = ArweaveClass.init({
       host: 'localhost',
       port: 1984,
       protocol: 'http',
     });
   } else {
-    arweave = Arweave.init({
+    arweave = ArweaveClass.init({
       host: 'arweave.net',
       port: 443,
       protocol: 'https',

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -47,16 +47,19 @@ export async function createTransaction<
     if (params.options?.useBundlr) {
       if (!params.key) {
         try {
-          if (window.ethereum) {
-            const Bundlr = await import(
-              '@bundlr-network/client/build/esm/web/bundlr'
-            );
+          if (typeof window !== 'undefined' && window.ethereum) {
+            const { WebBundlr } = await import('@bundlr-network/client');
             const provider = new ethers.BrowserProvider(window.ethereum);
             const signer = await provider.getSigner();
             // @ts-ignore
             provider.getSigner = () => signer;
-            const bundlr = new Bundlr.default(
-              'http://node2.bundlr.network',
+
+            // @ts-ignore
+            signer._signTypedData = (domain, types, value) =>
+              signer.signTypedData(domain, types, value);
+
+            const bundlr = new WebBundlr(
+              'https://node2.bundlr.network',
               'matic',
               provider
             );
@@ -120,11 +123,9 @@ export async function createTransaction<
           } as Types.CreateTransactionReturnProps<T>;
         }
       } else {
-        const Bundlr = await import(
-          '@bundlr-network/client/build/esm/node/bundlr'
-        );
-        const bundlr = new Bundlr.default(
-          'http://node2.bundlr.network',
+        const { NodeBundlr } = await import('@bundlr-network/client');
+        const bundlr = new NodeBundlr(
+          'https://node2.bundlr.network',
           'arweave',
           params.key
         );

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -3,15 +3,16 @@ import * as Types from '../types/wallet';
 import { generateMnemonic, getKeyFromMnemonic } from 'arweave-mnemonic-keys';
 
 const initArweave = (params: Types.InitArweaveProps) => {
-  let arweave;
+  let arweave: Arweave;
+  const ArweaveClass = (Arweave as any)?.default ?? Arweave;
   if (params.environment === 'local') {
-    arweave = Arweave.init({
+    arweave = ArweaveClass.init({
       host: 'localhost',
       port: 1984,
       protocol: 'http',
     });
   } else {
-    arweave = Arweave.init({
+    arweave = ArweaveClass.init({
       host: 'arweave.net',
       port: 443,
       protocol: 'https',

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,10 +432,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bundlr-network/client@0.11.9":
-  version "0.11.9"
-  resolved "https://registry.yarnpkg.com/@bundlr-network/client/-/client-0.11.9.tgz#c6d170e1ff74661af78547ed8bd8d84e09824f4a"
-  integrity sha512-0lZAB0kx+GZsIGPT+nN2tMLseAzg98hS1HEupRoZcuE9OoMOa4+H+SOTNEbmxp7kuDKoMC3TXN9GOJBXFcPe7Q==
+"@bundlr-network/client@^0.11.12":
+  version "0.11.12"
+  resolved "https://registry.npmjs.org/@bundlr-network/client/-/client-0.11.12.tgz#6542851407810407c24734ece6943c248906bb9c"
+  integrity sha512-wbWjIKsb8kRVSGNjhd7bEeYfRWhIx99cQQY1IYbYkg6GEgKKGB0MkHrNHkYlYkKazy3uBeObK1KhjHK7GF6quw==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
     "@ethersproject/contracts" "^5.7.0"
@@ -450,7 +450,7 @@
     algosdk "^1.13.1"
     aptos "^1.8.5"
     arbundles "^0.9.7"
-    arweave "=1.11.8"
+    arweave "=1.11.9"
     async-retry "^1.3.3"
     axios "^0.25.0"
     base64url "^3.0.1"
@@ -2445,6 +2445,18 @@ arweave@=1.11.8:
   version "1.11.8"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.11.8.tgz#09376e0c6cec40a661cbb27a306cb11c0a663cd8"
   integrity sha512-58ODeNPIC4OjaOCl2bXjKbOFGsiVZFs+DkQg3BvQGvFWNqw1zTJ4Jp01xGUz+GbdOaDyJcCC0g3l0HwdJfFPyw==
+  dependencies:
+    arconnect "^0.4.2"
+    asn1.js "^5.4.1"
+    axios "^0.27.2"
+    base64-js "^1.5.1"
+    bignumber.js "^9.0.2"
+    util "^0.12.4"
+
+arweave@=1.11.9:
+  version "1.11.9"
+  resolved "https://registry.npmjs.org/arweave/-/arweave-1.11.9.tgz#4d1fc17052e4e6d6eeb8fd18063b43eca52f2a56"
+  integrity sha512-i+oQQkQgjASG/+iS/BVq0JDhpW0jLGMtiqPwfHe0x46YCnuA23prN82EW4KigxZAphF9jNzDexQjGLAKbhw4Zw==
   dependencies:
     arconnect "^0.4.2"
     asn1.js "^5.4.1"


### PR DESCRIPTION
# ArweaveKit for Web

## Context

As a developer, I want to use ArweaveKit in frontend projects built using Vite, Webpack, etc. As of now, there are several dependency-related issues. While building any frontend project that uses arweavekit, it fails with errors that are related to unsupported dependencies in a browser environment. Even after attempting to polyfill many packages involved in the issue, this still remains to be a problem.

## Steps to reproduce

1. start a new react project using Vite or Webpack

2. install arweavekit with the command npm i arweavekit

3. import createTransaction method from arweavekit/transaction

4. build the app using npm run build

5. Build fails

## Bug Fixes
- Fix build issues caused by `@bundlr-network/client` package
- Fix arweave init issue in nextjs

## Manual Polyfill needed for `@bundlr-network/client` package in Vite & Webpack projects

- **Vite**: `Buffer` & other modules can be polyfilled  using [vite-plugin-node-polyfills](https://github.com/davidmyersdev/vite-plugin-node-polyfills)

  For example, Vite react project:
  
  > vite.config.ts
  ```ts
  import { defineConfig } from "vite";
  import react from "@vitejs/plugin-react-swc";
  import { nodePolyfills } from "vite-plugin-node-polyfills";
  
  // https://vitejs.dev/config/
  export default defineConfig({
    plugins: [react(), nodePolyfills()],
  });
  ```
  
- **Webpack**: `Buffer` & other modules can be polyfilled using [node-polyfill-webpack-plugin](https://github.com/Richienb/node-polyfill-webpack-plugin)

  For example, To polyfill the modules using arweavekit with npx create-react-app:
  
    Install first react-app-rewired, a package that allows for editing of the webpack config file to fix the polyfill issue.
    
    [https://docs.bundlr.network/developer-docs/recipes/react](https://docs.bundlr.network/developer-docs/recipes/react)
  
  
  