### PR TITLE
fix: use evaluation options for read

### DIFF
--- a/src/lib/contract.ts
+++ b/src/lib/contract.ts
@@ -388,7 +388,9 @@ export async function writeContract(params: Types.WriteContractProps) {
   };
   let { wallet, callbackResponse } = await initWalletCallback(params, callback);
 
-  const contract = warp.contract(params.contractTxId).connect(wallet);
+  const contract = warp.contract(params.contractTxId)
+    .setEvaluationOptions({ ...params.evaluationOptions })
+    .connect(wallet);
 
   const readState = await contract.readState();
 


### PR DESCRIPTION
in the `writeContract` function the `evaluationOptions` params are used when writing but not when reading.

I found when used with `{allowBigInt: true}` this means an error is thrown