### PR TITLE
feat: added getData to fetch raw data

### DIFF
--- a/__tests__/transaction/getData.spec.ts
+++ b/__tests__/transaction/getData.spec.ts
@@ -1,0 +1,62 @@
+import { getWallet } from './utils';
+import { createTransaction, getData } from '../../src';
+
+jest.setTimeout(300000);
+
+describe('Get Data', () => {
+  it('should get arweave transaction on local', async () => {
+    const key = await getWallet('local');
+
+    const txn = await createTransaction({
+      key: key,
+      type: 'data',
+      environment: 'local',
+      data: 'data',
+      options: {
+        signAndPost: true,
+      },
+    });
+
+    const getTxnData = await getData({
+      environment: 'local',
+      transactionId: txn.transaction.id,
+    });
+    console.log(getTxnData);
+
+    expect(getTxnData).toBeDefined();
+    expect(getTxnData).toBe('data');
+  });
+
+  it('should get arweave transaction on mainnet for Text', async () => {
+    const getTxn = await getData({
+      environment: 'mainnet',
+      transactionId: 'U9KJecUGw39-BdF0YFPZk5n-PHM2A0r9HefJ2H8jZ78',
+    });
+    expect(getTxn).toBeDefined();
+    expect(getTxn).toBe('hello');
+  });
+
+  it('should get arweave transaction on mainnet for JSON', async () => {
+    const getTxn = await getData({
+      environment: 'mainnet',
+      transactionId: 'chGa5cCOQRwjiDOABYQseAPesN0-qdxBTozDpNhl2nc',
+    });
+    console.log(getTxn);
+    expect(getTxn).toBeDefined();
+  });
+
+  it('should get arweave transaction on mainnet for PDF', async () => {
+    const getTxn = await getData({
+      environment: 'mainnet',
+      transactionId: 'N9miiLuCGzSst_ABLohAQbZGC_uG5h9raTfp3LLNAZg',
+    });
+    expect(getTxn).toBeDefined();
+  });
+  it('should get arweave transaction on mainnet for Image', async () => {
+    const getTxn = await getData({
+      environment: 'mainnet',
+      transactionId: 'vevXEz2AMl2ZMG6xCOwN0rO18tEqSezURVE-IkU38Ec',
+    });
+    expect(getTxn).toBeDefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   getTransaction,
   getTransactionStatus,
   createAndPostTransactionWOthent,
+  getData,
 } from './lib/transaction';
 export {
   createContract,

--- a/src/lib/transaction.ts
+++ b/src/lib/transaction.ts
@@ -304,6 +304,42 @@ export async function getTransaction(params: Types.GetTransactionProps) {
 }
 
 /**
+ *
+ * @param GetTransactionProps
+ * @returns TransactionData
+ */
+
+export async function getData(params: Types.GetTransactionProps) {
+  // Separate the URL from the parameters
+  const intialUrl =
+    params.environment === 'local'
+      ? 'http://127.0.0.1:1984/'
+      : 'https://arweave.net/';
+
+  const apiUrl = `${intialUrl}${params.transactionId}`;
+  try {
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch. Status Code: ${response.status}`);
+    }
+    const contentType = response.headers.get('content-type');
+    if (!contentType) {
+      throw new TypeError('No Content-type!');
+    } else if (contentType.includes('application/json')) {
+      const json = await response.json();
+      return json;
+    } else if (contentType.includes('text')) {
+      const text = await response.text();
+      return text;
+    } else {
+      const blob = await response.blob();
+      return blob;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+/**
  * CreateandPostTransactionWOthent
  * @params CreateandPostTransactionWOthentProps
  * @returns CreateandPostTransactionWOthentReturnProps

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -174,3 +174,7 @@ export interface CreateandPostTransactionWOthentReturnProps {
   success: boolean;
   transactionId: string;
 }
+
+export interface TransactionData {
+  data: string | Blob;
+}


### PR DESCRIPTION
Worked on Issue #89 

The data output is in the form of **JSON, Text, or Blob** to prevent the **bulkiness** of the function while also keeping in mind that most of the time it would be used to fetch a **JSON Object or a Text** with rare instances of calling other files which can be then converted into suitable by the user itself.

- Added Function for getData
- Wrote some tests
- Deprecated getTransaction Function